### PR TITLE
Add Selection Actions primitive

### DIFF
--- a/components/primitives/SelectionActions.tsx
+++ b/components/primitives/SelectionActions.tsx
@@ -1,0 +1,595 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowUp,
+  ChatBubbleQuestion,
+  Check,
+  EmojiSatisfied,
+  NavArrowRight,
+  Refresh,
+  Scissor,
+  Spark,
+  TextBox,
+  Xmark,
+} from "iconoir-react";
+import { Shimmer } from "@/components/atoms/Shimmer";
+
+/* ─────────────────────────────────────────────────────────
+ * SELECTION ACTIONS
+ * A contextual AI bar attached beneath selected text.
+ * The global theme owns its surface; this component only
+ * composes existing surface, ink, accent, radius and motion
+ * tokens.
+ * ───────────────────────────────────────────────────────── */
+
+const LEAD = "Pistachio holds the top slot all weekend. ";
+const PICKED =
+  "Churn it first thing Saturday so the batch has time to firm up before the afternoon rush.";
+const REWRITE =
+  "Churn pistachio first thing Saturday so the batch has time to fully firm before the afternoon rush.";
+
+const ORIGINAL_WORDS = PICKED.split(" ");
+const REWRITE_WORDS = REWRITE.split(" ");
+const WORD_MS = 80;
+
+type Mode = "idle" | "thinking" | "streaming" | "result";
+
+const iconProps = {
+  width: 14,
+  height: 14,
+  strokeWidth: 1.8,
+  "aria-hidden": true,
+} as const;
+
+const icons = {
+  explain: <ChatBubbleQuestion {...iconProps} />,
+  improve: <Spark {...iconProps} />,
+  shorten: <Scissor {...iconProps} />,
+  tone: <EmojiSatisfied {...iconProps} />,
+  grammar: <TextBox {...iconProps} />,
+  send: (
+    <ArrowUp
+      width="16"
+      height="16"
+      strokeWidth="2.4"
+      aria-hidden="true"
+    />
+  ),
+  chevron: <NavArrowRight {...iconProps} />,
+  check: <Check {...iconProps} />,
+  close: <Xmark {...iconProps} />,
+  retry: <Refresh {...iconProps} />,
+};
+
+const control =
+  "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full px-1.5 text-[12px] font-normal text-ink transition-[background-color,color,transform] duration-150 hover:bg-hover active:scale-[0.96]";
+
+const primary =
+  "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full bg-ink px-2.5 text-[12.5px] font-normal text-canvas shadow-hairline transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]";
+
+export default function SelectionActions() {
+  const [shown, setShown] = useState(false);
+  const [mode, setMode] = useState<Mode>("idle");
+  const [action, setAction] = useState("Improve");
+  const [prompt, setPrompt] = useState("");
+  const [typingWidth, setTypingWidth] = useState<number | null>(null);
+  const [count, setCount] = useState(0);
+  const [expanded, setExpanded] = useState(false);
+  const [anchor, setAnchor] = useState({ x: 0, y: 0 });
+  const [positioned, setPositioned] = useState(false);
+
+  const hostRef = useRef<HTMLDivElement>(null);
+  const selectionRef = useRef<HTMLSpanElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const frameRef = useRef<number | null>(null);
+  const previousModeRef = useRef<Mode>("idle");
+  const lastWidthRef = useRef(0);
+  const widthAnimationRef = useRef<Animation | null>(null);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setShown(true), 280);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (mode !== "thinking") return;
+    const timer = window.setTimeout(() => setMode("streaming"), 700);
+    return () => window.clearTimeout(timer);
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode !== "streaming") return;
+    if (count >= REWRITE_WORDS.length) {
+      const timer = window.setTimeout(() => setMode("result"), 220);
+      return () => window.clearTimeout(timer);
+    }
+    const timer = window.setTimeout(() => setCount((value) => value + 1), WORD_MS);
+    return () => window.clearTimeout(timer);
+  }, [count, mode]);
+
+  /* Attach beneath the final selected line, while centering the bar
+   * against the complete selection bounds. requestAnimationFrame batches
+   * streaming reflow measurements and avoids visible intermediate positions. */
+  const place = useCallback(() => {
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(() => {
+      const host = hostRef.current;
+      const selection = selectionRef.current;
+      if (!host || !selection) return;
+
+      const bounds = selection.getBoundingClientRect();
+      const lines = Array.from(selection.getClientRects());
+      const lastLine = lines.at(-1);
+      if (!lastLine) return;
+
+      const hostBounds = host.getBoundingClientRect();
+      const next = {
+        x: Math.round(bounds.left - hostBounds.left + bounds.width / 2),
+        y: Math.round(lastLine.bottom - hostBounds.top + 8),
+      };
+
+      setAnchor((current) =>
+        current.x === next.x && current.y === next.y ? current : next,
+      );
+      setPositioned(true);
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    place();
+  }, [count, mode, place]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const observer = new ResizeObserver(place);
+    observer.observe(host);
+    window.addEventListener("resize", place);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", place);
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, [place]);
+
+  /* Intrinsic width handles the preset expansion. When the entire content
+   * changes between idle, loading and confirmation, animate from the last
+   * rendered width to the new intrinsic width before the browser paints. */
+  useLayoutEffect(() => {
+    const bar = barRef.current;
+    const content = contentRef.current;
+    if (!bar || !content) return;
+
+    const nextWidth = Math.ceil(content.getBoundingClientRect().width) + 8;
+    const previousWidth =
+      lastWidthRef.current || Math.ceil(bar.getBoundingClientRect().width);
+
+    if (
+      previousModeRef.current !== mode &&
+      Math.abs(nextWidth - previousWidth) > 1
+    ) {
+      widthAnimationRef.current?.cancel();
+      const animation = bar.animate(
+        [
+          { width: `${previousWidth}px` },
+          { width: `${nextWidth}px` },
+        ],
+        {
+          duration: 320,
+          easing: "cubic-bezier(0.23,1,0.32,1)",
+        },
+      );
+      widthAnimationRef.current = animation;
+      animation.onfinish = () => {
+        lastWidthRef.current = nextWidth;
+        widthAnimationRef.current = null;
+      };
+    } else {
+      lastWidthRef.current = nextWidth;
+    }
+
+    previousModeRef.current = mode;
+  }, [mode]);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const observer = new ResizeObserver(() => {
+      if (widthAnimationRef.current?.playState === "running") return;
+      lastWidthRef.current =
+        Math.ceil(content.getBoundingClientRect().width) + 8;
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+      widthAnimationRef.current?.cancel();
+    };
+  }, []);
+
+  const run = (nextAction: string) => {
+    setAction(nextAction);
+    setExpanded(false);
+    setCount(0);
+    setMode("thinking");
+  };
+
+  const reset = () => {
+    setExpanded(false);
+    setPrompt("");
+    setTypingWidth(null);
+    setAction("Improve");
+    setCount(0);
+    setMode("idle");
+  };
+
+  const busy = mode === "thinking" || mode === "streaming";
+  const visible = shown && positioned;
+  const hasPrompt = prompt.trim().length > 0;
+  const busyLabel =
+    action === "Improve"
+      ? "Improving"
+      : action === "Shorten"
+        ? "Shortening"
+        : action === "Change tone"
+          ? "Changing tone"
+          : "Editing";
+
+  return (
+    <div className="w-full max-w-[460px]">
+      <div ref={hostRef} className="relative select-none pb-12">
+        <p className="text-[13px] leading-relaxed text-ink">
+          {LEAD}
+          <span
+            ref={selectionRef}
+            className="box-decoration-clone rounded-[3px] bg-[color-mix(in_srgb,var(--accent)_14%,var(--surface))] text-ink dark:bg-accent-tint"
+          >
+            {mode === "idle" || mode === "thinking"
+              ? PICKED
+              : ORIGINAL_WORDS.map((original, index) => {
+                  const complete = mode === "result" || index < count;
+                  const word = complete ? REWRITE_WORDS[index] : original;
+                  return (
+                    <span
+                      key={index}
+                      className={complete ? "text-ink" : "text-ink-3"}
+                      style={
+                        index === count - 1 && mode === "streaming"
+                          ? { animation: "fade-in 250ms ease-out both" }
+                          : undefined
+                      }
+                    >
+                      {word}
+                      {index < ORIGINAL_WORDS.length - 1 ? " " : ""}
+                      {index === count - 1 && mode === "streaming" && (
+                        <span className="ml-0.5 inline-block h-3 w-0.5 translate-y-0.5 rounded-full bg-ink" />
+                      )}
+                    </span>
+                  );
+                })}
+          </span>
+        </p>
+
+        {mode === "idle" && (
+          <SelectionHandles
+            hostRef={hostRef}
+            selectionRef={selectionRef}
+            visible={shown}
+          />
+        )}
+
+        <div
+          className="absolute top-0 left-0 z-10"
+          style={{
+            transform: `translate3d(${anchor.x}px, ${anchor.y}px, 0) translateX(-50%)`,
+            transition:
+              "transform 320ms cubic-bezier(0.77,0,0.175,1), opacity 180ms ease-out",
+            opacity: visible ? 1 : 0,
+            pointerEvents: visible ? "auto" : "none",
+            willChange: "transform",
+          }}
+        >
+          {/* A 36px pill wraps 28px controls at a 4px inset. The controls
+              resolve to a 14px radius, preserving the concentric curve. */}
+          <div
+            ref={barRef}
+            className="flex h-9 w-fit max-w-[calc(100vw-48px)] items-center justify-center gap-0.5 overflow-hidden rounded-full bg-surface p-1 font-sans font-normal text-ink antialiased shadow-overlay"
+            style={{
+              width:
+                mode === "idle" && hasPrompt && typingWidth
+                  ? typingWidth
+                  : undefined,
+              ...(visible
+                ? {
+                    animation:
+                      "pop-in 220ms cubic-bezier(0.23,1,0.32,1) both",
+                  }
+                : {}),
+            }}
+          >
+            <div
+              ref={contentRef}
+              className="flex w-fit shrink-0 items-center justify-center gap-0.5"
+              style={{
+                width:
+                  mode === "idle" && hasPrompt && typingWidth
+                    ? typingWidth - 8
+                    : undefined,
+              }}
+            >
+            {busy && (
+              <span className="inline-flex h-7 items-center gap-1.5 whitespace-nowrap px-2.5 text-[12.5px] font-normal text-ink-2">
+                <span
+                  className="size-3 shrink-0 rounded-full border-[1.5px] border-line-strong border-t-ink-2"
+                  style={{ animation: "spin 700ms linear infinite" }}
+                />
+                {mode === "thinking" ? (
+                  <Shimmer className="text-[12.5px] font-normal">
+                    {busyLabel}…
+                  </Shimmer>
+                ) : (
+                  <span>{busyLabel}…</span>
+                )}
+              </span>
+            )}
+
+            {mode === "result" && (
+              <>
+                <button
+                  type="button"
+                  onClick={reset}
+                  className={primary}
+                >
+                  {icons.check}
+                  Keep
+                </button>
+                <button type="button" onClick={reset} className={control}>
+                  {icons.close}
+                  Discard
+                </button>
+                <span className="mx-0.5 h-4 w-px shrink-0 bg-line" />
+                <button
+                  type="button"
+                  aria-label="Try again"
+                  onClick={() => run(action)}
+                  className="flex size-7 shrink-0 items-center justify-center rounded-full text-ink-3 transition-[background-color,color,transform] duration-150 hover:bg-hover-2 hover:text-ink-2 active:scale-[0.96]"
+                >
+                  {icons.retry}
+                </button>
+              </>
+            )}
+
+            {mode === "idle" && (
+              <>
+                <div
+                  className="flex min-w-0 items-center overflow-hidden transition-[max-width,opacity,transform] duration-400"
+                  style={{
+                    maxWidth: expanded
+                      ? 0
+                      : hasPrompt && typingWidth
+                        ? typingWidth - 40
+                        : 145,
+                    opacity: expanded ? 0 : 1,
+                    transform: expanded ? "translateX(-8px)" : "translateX(0)",
+                    transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                  }}
+                >
+                  <form
+                    className="flex h-7 shrink-0 items-center transition-[width] duration-400"
+                    style={{
+                      width:
+                        hasPrompt && typingWidth ? typingWidth - 40 : 145,
+                      transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                    }}
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      run(prompt.trim() || "Improve");
+                    }}
+                  >
+                    <input
+                      value={prompt}
+                      onChange={(event) => {
+                        const next = event.target.value;
+                        if (!prompt.trim() && next.trim()) {
+                          setTypingWidth(
+                            Math.ceil(
+                              barRef.current?.getBoundingClientRect().width ??
+                                0,
+                            ),
+                          );
+                        } else if (!next.trim()) {
+                          setTypingWidth(null);
+                        }
+                        setPrompt(next);
+                      }}
+                      aria-label="Describe edits"
+                      placeholder="Describe edits"
+                      className="h-7 w-full bg-transparent pr-2.5 pl-3 text-[12.5px] text-ink placeholder:text-ink-3"
+                    />
+                  </form>
+                </div>
+
+                <div
+                  className="flex min-w-0 items-center gap-0.5 overflow-hidden transition-[max-width,opacity,transform] duration-400"
+                  style={{
+                    maxWidth: hasPrompt ? 0 : expanded ? 430 : 206,
+                    opacity: hasPrompt ? 0 : 1,
+                    transform: hasPrompt ? "translateX(-8px)" : "translateX(0)",
+                    transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                  }}
+                >
+                  {!expanded && (
+                    <span className="mx-1 h-4 w-px shrink-0 bg-line-strong" />
+                  )}
+                  <button type="button" className={control}>
+                    {icons.explain}
+                    Explain
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => run("Improve")}
+                    className={control}
+                  >
+                    {icons.improve}
+                    Improve
+                  </button>
+
+                  <div
+                    className="flex min-w-0 items-center gap-0.5 overflow-hidden transition-[max-width,opacity,margin] duration-400"
+                    style={{
+                      maxWidth: expanded ? 238 : 0,
+                      opacity: expanded ? 1 : 0,
+                      marginLeft: expanded ? 2 : 0,
+                      transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                    }}
+                  >
+                  <button
+                    type="button"
+                    onClick={() => run("Shorten")}
+                    className={control}
+                  >
+                    {icons.shorten}
+                    Shorten
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => run("Change tone")}
+                    className={control}
+                  >
+                    {icons.tone}
+                    Tone
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => run("Fix grammar")}
+                    className={control}
+                  >
+                    {icons.grammar}
+                    Grammar
+                  </button>
+                  </div>
+
+                  <span className="mx-0.5 h-4 w-px shrink-0 bg-line" />
+                  <button
+                    type="button"
+                    aria-label={expanded ? "Show fewer actions" : "Show more actions"}
+                    aria-expanded={expanded}
+                    onClick={() => setExpanded((value) => !value)}
+                    className="flex size-7 shrink-0 items-center justify-center rounded-full text-ink transition-[background-color,transform] duration-200 hover:bg-hover active:scale-[0.96]"
+                  >
+                    <span
+                      className="flex transition-transform duration-400"
+                      style={{
+                        transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                        transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                      }}
+                    >
+                      {icons.chevron}
+                    </span>
+                  </button>
+                </div>
+
+                <div
+                  className="flex min-w-0 items-center overflow-hidden transition-[max-width,opacity,transform] duration-400"
+                  style={{
+                    maxWidth: hasPrompt ? 30 : 0,
+                    opacity: hasPrompt ? 1 : 0,
+                    transform: hasPrompt ? "scale(1)" : "scale(0.88)",
+                    transitionTimingFunction: "cubic-bezier(0.23,1,0.32,1)",
+                  }}
+                >
+                  <button
+                    type="button"
+                    aria-label="Send edit instruction"
+                    onClick={() => run(prompt.trim())}
+                    className="flex size-7 shrink-0 items-center justify-center rounded-full bg-ink text-surface transition-[opacity,transform] duration-200 active:scale-[0.94]"
+                  >
+                    {icons.send}
+                  </button>
+                </div>
+              </>
+            )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+}
+
+function SelectionHandles({
+  hostRef,
+  selectionRef,
+  visible,
+}: {
+  hostRef: React.RefObject<HTMLDivElement | null>;
+  selectionRef: React.RefObject<HTMLSpanElement | null>;
+  visible: boolean;
+}) {
+  const [edges, setEdges] = useState<
+    { left: number; top: number; height: number; edge: "start" | "end" }[]
+  >([]);
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    const selection = selectionRef.current;
+    if (!host || !selection) return;
+
+    const measure = () => {
+      const lines = Array.from(selection.getClientRects());
+      const first = lines[0];
+      const last = lines.at(-1);
+      if (!first || !last) return;
+      const hostBounds = host.getBoundingClientRect();
+      setEdges([
+        {
+          left: Math.round(first.left - hostBounds.left),
+          top: Math.round(first.top - hostBounds.top),
+          height: Math.round(first.height),
+          edge: "start",
+        },
+        {
+          left: Math.round(last.right - hostBounds.left),
+          top: Math.round(last.top - hostBounds.top),
+          height: Math.round(last.height),
+          edge: "end",
+        },
+      ]);
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, [hostRef, selectionRef]);
+
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-[1] transition-opacity duration-200"
+      style={{ opacity: visible ? 1 : 0 }}
+    >
+      {edges.map((item) => (
+        <span
+          key={item.edge}
+          className="absolute w-[1.5px] bg-accent"
+          style={{ left: item.left, top: item.top, height: item.height }}
+        >
+          <span
+            className="absolute left-1/2 size-2.5 -translate-x-1/2 rounded-full bg-accent shadow-[0_0_0_1px_var(--surface)]"
+            style={item.edge === "start" ? { top: -8 } : { bottom: -8 }}
+          />
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/components/primitives/SelectionActions.tsx
+++ b/components/primitives/SelectionActions.tsx
@@ -278,14 +278,6 @@ export default function SelectionActions() {
           </span>
         </p>
 
-        {mode === "idle" && (
-          <SelectionHandles
-            hostRef={hostRef}
-            selectionRef={selectionRef}
-            visible={shown}
-          />
-        )}
-
         <div
           className="absolute top-0 left-0 z-10"
           style={{
@@ -523,73 +515,5 @@ export default function SelectionActions() {
       </div>
 
     </div>
-  );
-}
-
-function SelectionHandles({
-  hostRef,
-  selectionRef,
-  visible,
-}: {
-  hostRef: React.RefObject<HTMLDivElement | null>;
-  selectionRef: React.RefObject<HTMLSpanElement | null>;
-  visible: boolean;
-}) {
-  const [edges, setEdges] = useState<
-    { left: number; top: number; height: number; edge: "start" | "end" }[]
-  >([]);
-
-  useLayoutEffect(() => {
-    const host = hostRef.current;
-    const selection = selectionRef.current;
-    if (!host || !selection) return;
-
-    const measure = () => {
-      const lines = Array.from(selection.getClientRects());
-      const first = lines[0];
-      const last = lines.at(-1);
-      if (!first || !last) return;
-      const hostBounds = host.getBoundingClientRect();
-      setEdges([
-        {
-          left: Math.round(first.left - hostBounds.left),
-          top: Math.round(first.top - hostBounds.top),
-          height: Math.round(first.height),
-          edge: "start",
-        },
-        {
-          left: Math.round(last.right - hostBounds.left),
-          top: Math.round(last.top - hostBounds.top),
-          height: Math.round(last.height),
-          edge: "end",
-        },
-      ]);
-    };
-
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(host);
-    return () => observer.disconnect();
-  }, [hostRef, selectionRef]);
-
-  return (
-    <span
-      aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-[1] transition-opacity duration-200"
-      style={{ opacity: visible ? 1 : 0 }}
-    >
-      {edges.map((item) => (
-        <span
-          key={item.edge}
-          className="absolute w-[1.5px] bg-accent"
-          style={{ left: item.left, top: item.top, height: item.height }}
-        >
-          <span
-            className="absolute left-1/2 size-2.5 -translate-x-1/2 rounded-full bg-accent shadow-[0_0_0_1px_var(--surface)]"
-            style={item.edge === "start" ? { top: -8 } : { bottom: -8 }}
-          />
-        </span>
-      ))}
-    </span>
   );
 }

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -119,4 +119,10 @@ export const META: Meta[] = [
     caption: "The agent adjusts design properties in an inspector.",
     file: "FineTuneCard.tsx",
   },
+  {
+    id: "selection-actions",
+    title: "Selection Actions",
+    caption: "Highlight a passage and hand it to the agent to rewrite.",
+    file: "SelectionActions.tsx",
+  },
 ];

--- a/lib/registry.tsx
+++ b/lib/registry.tsx
@@ -20,6 +20,7 @@ import InsightCards from "@/components/primitives/InsightCards";
 import CodeBlock from "@/components/primitives/CodeBlock";
 import ToolChips from "@/components/primitives/ToolChips";
 import SearchList from "@/components/primitives/SearchList";
+import SelectionActions from "@/components/primitives/SelectionActions";
 
 export type Entry = Meta & { Demo: ComponentType<{ variant?: string }> };
 
@@ -42,6 +43,7 @@ const DEMOS: Record<string, ComponentType<{ variant?: string }>> = {
   "code-block": CodeBlock,
   "tool-chips": ToolChips,
   "search": SearchList,
+  "selection-actions": SelectionActions,
 };
 
 export const REGISTRY: Entry[] = META.map((m) => ({ ...m, Demo: DEMOS[m.id] }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "glimm": "^0.3.0",
+        "iconoir-react": "^7.11.1",
         "liveline": "^0.0.7",
         "next": "^15.3.3",
         "react": "^19.1.0",
@@ -993,6 +994,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1110,6 +1112,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iconoir-react": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/iconoir-react/-/iconoir-react-7.11.1.tgz",
+      "integrity": "sha512-uUdoKZ5SvvleMWf+mJWbAxLt5WaEcvBAU3YmO5Ho+JA5JLxBKntT0KNXpJqQArq7b5DxiN5xobIVoDBIPAvA/w==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/iconoir"
+      },
+      "peerDependencies": {
+        "react": "18 || 19"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -1427,6 +1442,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
       "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.20",
         "@swc/helpers": "0.5.15",
@@ -1542,6 +1558,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1551,6 +1568,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "glimm": "^0.3.0",
+    "iconoir-react": "^7.11.1",
     "liveline": "^0.0.7",
     "next": "^15.3.3",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- Adds a new **Selection Actions** primitive: free-form “Describe edits” prompt, AI presets (Explain, Improve, Shorten, Tone, Grammar), typing→send affordance, and Keep/Discard confirmation
- Uses Iconoir icons and existing Beautiful UI tokens/motion patterns
- Registered in the catalog (`meta` + `registry`) so it shows on the site

## Test plan
- [ ] Open `/#selection-actions` on this branch
- [ ] Expand/collapse presets and confirm all actions are visible
- [ ] Type in Describe edits → presets collapse, send appears, bar width stays locked
- [ ] Run Improve (or Enter) → loading → rewrite stream → Keep/Discard returns to default
- [ ] Check light and dark theme