### PR TITLE
Match approval-card button height across primitives

### DIFF
--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,8 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
-        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — 27px tall, roomy sides */
+        sm: "h-[27px] px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },

--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,7 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        sm: "px-3 py-[7px] text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
+        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },


### PR DESCRIPTION
## What

The `sm` Button size drove its height from vertical padding (`px-3 py-[7px]`, ~27px). The Approval Card footer needed a shorter, cleaner pill, so it carried a one-off `h-6 py-0` override — leaving DiffTable / RecommendationCard visibly taller than the Approval Card's buttons.

This bakes the skinny pill into the shared `sm` variant so every card action button matches:

```diff
- sm: "px-3 py-[7px] text-[13px] leading-none rounded-full gap-1.5",   // ~27px
+ sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",        // 24px, roomy sides
```

## Ripple
- **ApprovalCard** — dropped the now-redundant `h-6 py-0` override; inherits it from the atom.
- **DiffTable** (Apply changes) and **RecommendationCard** (Alternatives / Accept) — inherit the 24px height automatically; they only override horizontal padding / text size.

## Left alone
- **SelectionActions** uses `size="xs"` (`h-7`), tuned to align with the `h-7` input and `size-7` retry control inside that floating toolbar.
- `md` (default, ~31px) is now only referenced by the Foundations showcase demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)