### PR TITLE
Host Surfer video on Blob + equalize Flowchart node padding

### DIFF
--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,8 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
-        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — 27px tall, roomy sides */
+        sm: "h-[27px] px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },

--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,7 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        sm: "px-3 py-[7px] text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
+        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },

--- a/components/primitives/Flowchart.tsx
+++ b/components/primitives/Flowchart.tsx
@@ -306,7 +306,7 @@ function ConditionBody() {
 
 function StepBody({ node }: { node: StepNode }) {
   return (
-    <div className="flex items-center gap-2.5 px-3 py-2.5">
+    <div className="flex items-center gap-2.5 p-2.5">
       <span
         className="flex size-9 shrink-0 items-center justify-center rounded-[8px]"
         style={{

--- a/components/primitives/LoadingState.tsx
+++ b/components/primitives/LoadingState.tsx
@@ -74,8 +74,9 @@ function useElapsed() {
 export default function LoadingState({
   label,
   variant = "Drive",
-  /** the meme feed for the Surfer variant; drop the file in /public to light it up */
-  videoSrc = "/subway-surfers.mp4",
+  /** the meme feed for the Surfer variant; hosted on Vercel Blob so it plays in
+   *  production (the local /public/subway-surfers.mp4 stays gitignored) */
+  videoSrc = "https://95dnc2a95qgwt9ff.public.blob.vercel-storage.com/subway-surfers.mp4",
 }: {
   label?: string;
   variant?: string;


### PR DESCRIPTION
## Surfer video → Vercel Blob
The `Surfer` loading variant played `/subway-surfers.mp4` from `/public`, but that file is gitignored (deliberately unpublished), so production showed "Video unavailable." Uploaded the video to a public Vercel Blob store (`beautiful-ui-blob`) and pointed the component's default `videoSrc` at the CDN URL, so it plays in production without committing copyrighted footage into the repo.

## Flowchart node padding
`StepBody` used `px-3 py-2.5` (12px sides, 10px top/bottom) — unequal padding around the leading icon chip. Changed to `p-2.5` so the icon-to-edge gap is equal on all four sides and matches the 10px card radius.

Per the design rule: for an **icon in a card**, concentric radii don't apply — the icon-to-edge gap is the independent variable and the container radius is derived from it (10px gap → 10px radius), rather than inner-radius + gap (which would be 18px). Codified in the `beautiful-ui` skill's anti-patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)