### PR TITLE
Flowchart: equal icon padding via tighter title leading

### DIFF
--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,8 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
-        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — 27px tall, roomy sides */
+        sm: "h-[27px] px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },

--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -26,7 +26,8 @@ export const buttonVariants = cva(
       size: {
         /* compact toolbar pill — fixed height, lighter weight */
         xs: "h-7 rounded-full px-2.5 text-[12px] font-normal leading-none gap-1",
-        sm: "px-3 py-[7px] text-[13px] leading-none rounded-full gap-1.5",
+        /* canonical action pill — skinny, roomy sides (matches Approval Card) */
+        sm: "h-6 px-3 text-[13px] leading-none rounded-full gap-1.5",
         md: "px-4 py-[9px] text-sm leading-none rounded-full gap-2",
       },
     },

--- a/components/primitives/Flowchart.tsx
+++ b/components/primitives/Flowchart.tsx
@@ -508,7 +508,7 @@ export default function Flowchart({ steps = NODES }: { steps?: StepNode[]; varia
               </span>
             )}
             {node.condition ? (
-              <div className="w-full rounded-card bg-surface shadow-card transition-shadow duration-150 hover:shadow-raised">
+              <div className="w-full rounded-[18px] bg-surface shadow-card transition-shadow duration-150 hover:shadow-raised">
                 <ConditionBody />
               </div>
             ) : (
@@ -519,7 +519,7 @@ export default function Flowchart({ steps = NODES }: { steps?: StepNode[]; varia
                   setSelected(active ? null : node.id);
                 }}
                 aria-pressed={active}
-                className={`w-full cursor-pointer rounded-card bg-surface text-left outline-none
+                className={`w-full cursor-pointer rounded-[18px] bg-surface text-left outline-none
                   transition-shadow duration-150 focus-visible:shadow-[0_0_0_1.5px_var(--accent)]
                   ${
                     active

--- a/components/primitives/Flowchart.tsx
+++ b/components/primitives/Flowchart.tsx
@@ -306,7 +306,7 @@ function ConditionBody() {
 
 function StepBody({ node }: { node: StepNode }) {
   return (
-    <div className="flex items-center gap-2.5 px-3 py-2.5">
+    <div className="flex items-center gap-2.5 p-2.5">
       <span
         className="flex size-9 shrink-0 items-center justify-center rounded-[8px]"
         style={{

--- a/components/primitives/Flowchart.tsx
+++ b/components/primitives/Flowchart.tsx
@@ -318,7 +318,7 @@ function StepBody({ node }: { node: StepNode }) {
         <ConeIcon />
       </span>
       <span className="min-w-0 text-left">
-        <span className="block truncate text-[13px] font-semibold text-ink">{node.title}</span>
+        <span className="block truncate text-[13px] font-semibold leading-tight text-ink">{node.title}</span>
         <span className="mt-0.5 block text-[12px] leading-snug text-ink-2">{node.caption}</span>
       </span>
     </div>

--- a/components/primitives/LoadingState.tsx
+++ b/components/primitives/LoadingState.tsx
@@ -74,8 +74,9 @@ function useElapsed() {
 export default function LoadingState({
   label,
   variant = "Drive",
-  /** the meme feed for the Surfer variant; drop the file in /public to light it up */
-  videoSrc = "/subway-surfers.mp4",
+  /** the meme feed for the Surfer variant; hosted on Vercel Blob so it plays in
+   *  production (the local /public/subway-surfers.mp4 stays gitignored) */
+  videoSrc = "https://95dnc2a95qgwt9ff.public.blob.vercel-storage.com/subway-surfers.mp4",
 }: {
   label?: string;
   variant?: string;


### PR DESCRIPTION
Follow-up to the node radius work. The icon looked ~1px closer on the sides than top/bottom.

Cause: the node title had no explicit line-height, so it inherited `body { line-height: 1.5 }` → the text column rendered ~38px, taller than the 36px icon. With `items-center`, the icon centered in the taller row and sat ~11px from top/bottom vs 10px on the left.

Fix: `leading-tight` on the title so the text column is < 36px and the **icon** governs the row height → equal 10px gaps on all four sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)